### PR TITLE
Fixes epochs loop in example from chapter 2

### DIFF
--- a/Chapter02/Completed/LinearRegression.playground/Contents.swift
+++ b/Chapter02/Completed/LinearRegression.playground/Contents.swift
@@ -102,7 +102,7 @@ func train(
     
     let N = CGFloat(x.count) // number of data points
     
-    for epoch in 0...epochs{
+    for epoch in 0..<epochs{
         var sumError : CGFloat = 0.0
         var bGradient : CGFloat = 0.0
         var wGradient : CGFloat = 0.0

--- a/Chapter02/Start/LinearRegression.playground/Contents.swift
+++ b/Chapter02/Start/LinearRegression.playground/Contents.swift
@@ -73,7 +73,7 @@ func train(
     
     let N = CGFloat(x.count) // number of data points
     
-    for epoch in 0...epochs{
+    for epoch in 0..<epochs{
         // TODO: create variable to store this epoch's gradient for b and w
         
         /**


### PR DESCRIPTION
On page 41 `epoch` is explained: The number of times we iterate.
That means loop is incorrect because it iterates one extra time.